### PR TITLE
Add server API


### DIFF
--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -1,0 +1,36 @@
+const express = require('express');
+const app = express();
+const port = 3000;
+
+// Fake data for tasks
+const tasks = [
+  {
+    id: 1,
+    description: 'Complete monthly financial report'
+  },
+  {
+    id: 2,
+    description: 'Plan team building activity'
+  },
+  {
+    id: 3,
+    description: 'Update project documentation'
+  }
+];
+
+app.get('/search', (req, res) => {
+  // Retrieve the query parameter
+  const query = req.query.query?.toLowerCase() || '';
+
+  // Filter tasks based on the query
+  const filteredTasks = tasks.filter(task => task.description.toLowerCase().includes(query));
+
+  // Sort the filtered tasks alphabetically by description
+  const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
+
+  res.json(sortedTasks);
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/graphite-demo/server.js
+++ b/graphite-demo/server.js
@@ -27,7 +27,7 @@ app.get('/search', (req, res) => {
 
   // Sort the filtered tasks alphabetically by description
   const sortedTasks = filteredTasks.sort((a, b) => a.description.localeCompare(b.description));
-
+  // Adding a comment here
   res.json(sortedTasks);
 });
 


### PR DESCRIPTION
### TL;DR

Added a new Express.js server with a task search API endpoint

### What changed?

Created `server.js` in the `graphite-demo` directory that implements an Express server running on port 3000. The server includes:

- A hardcoded array of three tasks with id and description fields
- A `/search` GET endpoint that accepts a `query` parameter to filter tasks by description
- Task filtering using case-insensitive substring matching
- Alphabetical sorting of filtered results by description

### How to test?

1. Navigate to the `graphite-demo` directory
2. Install dependencies: `npm install express`
3. Start the server: `node server.js`
4. Test the search endpoint:
    - `GET http://localhost:3000/search` - returns all tasks sorted alphabetically
    - `GET http://localhost:3000/search?query=report` - returns tasks containing "report"
    - `GET http://localhost:3000/search?query=team` - returns tasks containing "team"

### Why make this change?

This establishes the foundation for a task management application by providing a basic REST API for searching and retrieving tasks, enabling future frontend integration and additional functionality.

| [Screen Recording 2026-03-02 at 11.55.59 AM.mov <span class="graphite__hidden"> <img class="grapihte__hidden" src="https://app.graphite.com/user-attachments/video/d6862099-4bc1-406a-b7b3-20d36423c408.mov"/>](https://app.graphite.com/user-attachments/video/d6862099-4bc1-406a-b7b3-20d36423c408.mov) |  |
| --- | --- |
|  |  |